### PR TITLE
Upgrade to cson-safe v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "async": "^0.9.0",
     "coffee-script": "^1.7.1",
     "cpr": "^0.2.0",
-    "cson-safe": "^0.1.1",
+    "cson-safe": "^1.0.0",
     "decompress": "^0.2.3",
     "mkdirp": "^0.5.0",
     "request": "^2.36.0",


### PR DESCRIPTION
The big change in v1.0.0 is that cson-safe now uses coffee-script
instead of -redux for parsing. This leads to less confusing behavior in
the subtle cases where -redux does not match coffee-script behavior. It
also collapses the dependency tree from a gazillion packages down to
one.